### PR TITLE
feat(lifecycle-hooks): add node pre and postExecute external hooks

### DIFF
--- a/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
+++ b/packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts
@@ -157,6 +157,15 @@ describe('Execution Lifecycle Hooks', () => {
 					nodeName,
 				});
 			});
+
+			it('should run node.preExecute hook', async () => {
+				await lifecycleHooks.runHook('nodeExecuteBefore', [nodeName, taskStartedData]);
+
+				expect(externalHooks.run).toHaveBeenCalledWith('node.preExecute', [
+					nodeName,
+					taskStartedData,
+				]);
+			});
 		});
 
 		describe('nodeExecuteAfter', () => {
@@ -169,6 +178,16 @@ describe('Execution Lifecycle Hooks', () => {
 					nodeName,
 				});
 			});
+
+			it('should run node.postExecute hook', async () => {
+				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
+
+				expect(externalHooks.run).toHaveBeenCalledWith('node.postExecute', [
+					nodeName,
+					taskData,
+					{ ...runExecutionData, executionId },
+				]);
+			});
 		});
 	};
 
@@ -177,7 +196,11 @@ describe('Execution Lifecycle Hooks', () => {
 			it('should run workflow.preExecute hook', async () => {
 				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
 
-				expect(externalHooks.run).toHaveBeenCalledWith('workflow.preExecute', [workflow, 'manual']);
+				expect(externalHooks.run).toHaveBeenCalledWith('workflow.preExecute', [
+					workflow,
+					'manual',
+					executionId,
+				]);
 			});
 		});
 
@@ -239,8 +262,8 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(lifecycleHooks.workflowData).toEqual(workflowData);
 
 			const { handlers } = lifecycleHooks;
-			expect(handlers.nodeExecuteBefore).toHaveLength(2);
-			expect(handlers.nodeExecuteAfter).toHaveLength(2);
+			expect(handlers.nodeExecuteBefore).toHaveLength(3);
+			expect(handlers.nodeExecuteAfter).toHaveLength(3);
 			expect(handlers.workflowExecuteBefore).toHaveLength(3);
 			expect(handlers.workflowExecuteAfter).toHaveLength(5);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
@@ -272,7 +295,7 @@ describe('Execution Lifecycle Hooks', () => {
 				workflowData.settings = { saveExecutionProgress: true };
 				lifecycleHooks = createHooks();
 
-				expect(lifecycleHooks.handlers.nodeExecuteAfter).toHaveLength(3);
+				expect(lifecycleHooks.handlers.nodeExecuteAfter).toHaveLength(4);
 
 				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
 
@@ -286,7 +309,7 @@ describe('Execution Lifecycle Hooks', () => {
 				workflowData.settings = { saveExecutionProgress: false };
 				lifecycleHooks = createHooks();
 
-				expect(lifecycleHooks.handlers.nodeExecuteAfter).toHaveLength(2);
+				expect(lifecycleHooks.handlers.nodeExecuteAfter).toHaveLength(3);
 
 				await lifecycleHooks.runHook('nodeExecuteAfter', [nodeName, taskData, runExecutionData]);
 
@@ -318,7 +341,11 @@ describe('Execution Lifecycle Hooks', () => {
 			it('should run workflow.preExecute external hook', async () => {
 				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
 
-				expect(externalHooks.run).toHaveBeenCalledWith('workflow.preExecute', [workflow, 'manual']);
+				expect(externalHooks.run).toHaveBeenCalledWith('workflow.preExecute', [
+					workflow,
+					'manual',
+					executionId,
+				]);
 			});
 		});
 
@@ -516,8 +543,8 @@ describe('Execution Lifecycle Hooks', () => {
 
 			it('should not setup any push hooks', async () => {
 				const { handlers } = lifecycleHooks;
-				expect(handlers.nodeExecuteBefore).toHaveLength(1);
-				expect(handlers.nodeExecuteAfter).toHaveLength(1);
+				expect(handlers.nodeExecuteBefore).toHaveLength(2);
+				expect(handlers.nodeExecuteAfter).toHaveLength(2);
 				expect(handlers.workflowExecuteBefore).toHaveLength(2);
 				expect(handlers.workflowExecuteAfter).toHaveLength(4);
 
@@ -567,7 +594,11 @@ describe('Execution Lifecycle Hooks', () => {
 			it('should run the workflow.preExecute external hook', async () => {
 				await lifecycleHooks.runHook('workflowExecuteBefore', [workflow, runExecutionData]);
 
-				expect(externalHooks.run).toHaveBeenCalledWith('workflow.preExecute', [workflow, 'manual']);
+				expect(externalHooks.run).toHaveBeenCalledWith('workflow.preExecute', [
+					workflow,
+					'manual',
+					executionId,
+				]);
 			});
 		});
 
@@ -642,8 +673,8 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(lifecycleHooks.workflowData).toEqual(workflowData);
 
 			const { handlers } = lifecycleHooks;
-			expect(handlers.nodeExecuteBefore).toHaveLength(2);
-			expect(handlers.nodeExecuteAfter).toHaveLength(2);
+			expect(handlers.nodeExecuteBefore).toHaveLength(3);
+			expect(handlers.nodeExecuteAfter).toHaveLength(3);
 			expect(handlers.workflowExecuteBefore).toHaveLength(2);
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
 			expect(handlers.nodeFetchedData).toHaveLength(1);
@@ -739,8 +770,8 @@ describe('Execution Lifecycle Hooks', () => {
 			expect(lifecycleHooks.workflowData).toEqual(workflowData);
 
 			const { handlers } = lifecycleHooks;
-			expect(handlers.nodeExecuteBefore).toHaveLength(1);
-			expect(handlers.nodeExecuteAfter).toHaveLength(1);
+			expect(handlers.nodeExecuteBefore).toHaveLength(2);
+			expect(handlers.nodeExecuteAfter).toHaveLength(2);
 			expect(handlers.workflowExecuteBefore).toHaveLength(2);
 			expect(handlers.workflowExecuteAfter).toHaveLength(4);
 			expect(handlers.nodeFetchedData).toHaveLength(1);

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -145,8 +145,21 @@ function hookFunctionsPush(
 
 function hookFunctionsExternalHooks(hooks: ExecutionLifecycleHooks) {
 	const externalHooks = Container.get(ExternalHooks);
+	hooks.addHandler('nodeExecuteBefore', async function (nodeName, taskData) {
+		await externalHooks.run('node.preExecute', [nodeName, taskData]);
+	});
+	hooks.addHandler('nodeExecuteAfter', async function (nodeName, taskData, executionData) {
+		const { executionId } = this;
+
+		await externalHooks.run('node.postExecute', [
+			nodeName,
+			taskData,
+			{ ...executionData, executionId },
+		]);
+	});
 	hooks.addHandler('workflowExecuteBefore', async function (workflow) {
-		await externalHooks.run('workflow.preExecute', [workflow, this.mode]);
+		const { executionId } = this;
+		await externalHooks.run('workflow.preExecute', [workflow, this.mode, executionId]);
 	});
 	hooks.addHandler('workflowExecuteAfter', async function (fullRunData) {
 		await externalHooks.run('workflow.postExecute', [

--- a/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
+++ b/packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts
@@ -379,13 +379,13 @@ export function getLifecycleHooksForSubExecutions(
 ): ExecutionLifecycleHooks {
 	const hooks = new ExecutionLifecycleHooks(mode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
+	hookFunctionsExternalHooks(hooks);
 	hookFunctionsWorkflowEvents(hooks, userId);
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 	hookFunctionsSave(hooks, { saveSettings });
 	hookFunctionsSaveProgress(hooks, { saveSettings });
 	hookFunctionsStatistics(hooks);
-	hookFunctionsExternalHooks(hooks);
 	return hooks;
 }
 
@@ -400,12 +400,12 @@ export function getLifecycleHooksForScalingWorker(
 	const hooks = new ExecutionLifecycleHooks(executionMode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
 	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
+	hookFunctionsExternalHooks(hooks);
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 	hookFunctionsSaveWorker(hooks, optionalParameters);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
 	hookFunctionsStatistics(hooks);
-	hookFunctionsExternalHooks(hooks);
 
 	if (executionMode === 'manual' && Container.get(InstanceSettings).isWorker) {
 		hookFunctionsPush(hooks, optionalParameters);
@@ -429,9 +429,9 @@ export function getLifecycleHooksForScalingMain(
 	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
 	const executionRepository = Container.get(ExecutionRepository);
 
+	hookFunctionsExternalHooks(hooks);
 	hookFunctionsWorkflowEvents(hooks, userId);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
-	hookFunctionsExternalHooks(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
 
 	hooks.addHandler('workflowExecuteAfter', async function (fullRunData) {
@@ -489,6 +489,7 @@ export function getLifecycleHooksForRegularMain(
 	const hooks = new ExecutionLifecycleHooks(executionMode, executionId, workflowData);
 	const saveSettings = toSaveSettings(workflowData.settings);
 	const optionalParameters = { pushRef, retryOf: retryOf ?? undefined, saveSettings };
+	hookFunctionsExternalHooks(hooks);
 	hookFunctionsWorkflowEvents(hooks, userId);
 	hookFunctionsNodeEvents(hooks);
 	hookFunctionsFinalizeExecutionStatus(hooks);
@@ -496,7 +497,6 @@ export function getLifecycleHooksForRegularMain(
 	hookFunctionsPush(hooks, optionalParameters);
 	hookFunctionsSaveProgress(hooks, optionalParameters);
 	hookFunctionsStatistics(hooks);
-	hookFunctionsExternalHooks(hooks);
 	Container.get(ModuleRegistry).registerLifecycleHooks(hooks);
 	return hooks;
 }

--- a/packages/cli/src/external-hooks.ts
+++ b/packages/cli/src/external-hooks.ts
@@ -9,8 +9,16 @@ import {
 	UserRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { ErrorReporter, Logger } from 'n8n-core';
-import type { IRun, IWorkflowBase, Workflow, WorkflowExecuteMode } from 'n8n-workflow';
+import { ErrorReporter } from 'n8n-core';
+import type {
+	IRun,
+	IRunExecutionData,
+	ITaskData,
+	ITaskStartedData,
+	IWorkflowBase,
+	Workflow,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
 import { UnexpectedError } from 'n8n-workflow';
 import type clientOAuth1 from 'oauth-1.0a';
 
@@ -73,11 +81,17 @@ type ExternalHooksMap = {
 	'workflow.afterArchive': [workflowId: string];
 	'workflow.afterUnarchive': [workflowId: string];
 
-	'workflow.preExecute': [workflow: Workflow, mode: WorkflowExecuteMode];
+	'workflow.preExecute': [workflow: Workflow, mode: WorkflowExecuteMode, executionId: string];
 	'workflow.postExecute': [
 		fullRunData: IRun | undefined,
 		workflowData: IWorkflowBase,
 		executionId: string,
+	];
+	'node.preExecute': [nodeName: string, taskData: ITaskStartedData];
+	'node.postExecute': [
+		nodeName: string,
+		taskData: ITaskData,
+		runData: IRunExecutionData & { executionId: string },
 	];
 };
 type HookNames = keyof ExternalHooksMap;


### PR DESCRIPTION
## Summary

This PR adds the capability to define external Hooks which get executed before and/or after each node execution. This is done by exposing the existing nodeExecuteBefore and nodeExecuteAfter hooks to the outside.

### Changes made:

* Added `node.pre/postExecute` external hooks
* Trigger `node.pre/postExecute` on `nodeExecuteBefore/nodeExecuteAfter`
* Added `executionId` to `workflow.preExecute`

### Testing

* Create external hook file containing `node.preExecute` and `node.postExecute` external hooks
* Trigger some workflow
* Verify hooks have been called
